### PR TITLE
Deploy script should re-use existing version number file

### DIFF
--- a/Build.GatherReleaseNotes.msbuild
+++ b/Build.GatherReleaseNotes.msbuild
@@ -35,6 +35,8 @@
     
     <Import Project="$(MsBuildExtensionsPath)\FindToolFromPackages.msbuild" 
             Condition="Exists('$(MsBuildExtensionsPath)\FindToolFromPackages.msbuild')" />
+    <Import Project="$(MsBuildExtensionsPath)\CalculateSemanticVersion.msbuild" 
+            Condition="Exists('$(MsBuildExtensionsPath)\CalculateSemanticVersion.msbuild')" />
     <Import Project="$(MsBuildExtensionsPath)\GetSemanticVersion.msbuild" 
             Condition="Exists('$(MsBuildExtensionsPath)\GetSemanticVersion.msbuild')" />
     <Import Project="$(MsBuildExtensionsPath)\TemplateFile.msbuild"
@@ -53,13 +55,16 @@
     
     <PropertyGroup>
         <FileGitVersionExe>GitHubFlowVersion.exe</FileGitVersionExe>
+        <FileSemanticVersion>$(DirBuildTemp)\semantic_version.json</FileSemanticVersion>
     </PropertyGroup>
     <Target Name="_GetSemanticVersion">
         <FindToolFromPackages PackagesDir="$(DirPackages)" FileToLocate="$(FileGitVersionExe)">
             <Output TaskParameter="Path" PropertyName="PathGitVersionExe" />
         </FindToolFromPackages>
         
-        <GetSemanticVersion ExePath="$(PathGitVersionExe)" TempDirectory="$(DirBuildTemp)">
+        <CalculateSemanticVersion ExePath="$(PathGitVersionExe)" VersionFile="$(FileSemanticVersion)" Condition="!Exists('$(FileSemanticVersion)')" />
+        
+        <GetSemanticVersion VersionFile="$(FileSemanticVersion)">
             <Output TaskParameter="VersionSemantic" PropertyName="VersionSemantic" />
         </GetSemanticVersion>
     </Target>

--- a/Build.Package.Archive.msbuild
+++ b/Build.Package.Archive.msbuild
@@ -26,9 +26,6 @@
     <Import Project="$(MsBuildExtensionsPath)\Zip.msbuild"
             Condition="Exists('$(MsBuildExtensionsPath)\Zip.msbuild')"/>
             
-    <Import Project="$(DirWorkspace)\version.xml" 
-            Condition="Exists('$(DirWorkspace)\version.xml')" />
-    
     <Target Name="Run" DependsOnTargets="_DisplayInfo;_GatherReleaseNotes;_PackageConsole;_PackageService;_PackageMasterService;_PackageExecutorService">
         <!-- Do nothing here -->
     </Target>

--- a/Build.Package.NuGet.msbuild
+++ b/Build.Package.NuGet.msbuild
@@ -50,14 +50,10 @@
     </Target>
     
     <PropertyGroup>
-        <FileGitVersionExe>GitHubFlowVersion.exe</FileGitVersionExe>
+        <FileSemanticVersion>$(DirBuildTemp)\semantic_version.json</FileSemanticVersion>
     </PropertyGroup>
     <Target Name="_GetSemanticVersion">
-        <FindToolFromPackages PackagesDir="$(DirPackages)" FileToLocate="$(FileGitVersionExe)">
-            <Output TaskParameter="Path" PropertyName="PathGitVersionExe" />
-        </FindToolFromPackages>
-        
-        <GetSemanticVersion ExePath="$(PathGitVersionExe)" TempDirectory="$(DirBuildTemp)">
+        <GetSemanticVersion VersionFile="$(FileSemanticVersion)">
             <Output TaskParameter="VersionSemantic" PropertyName="VersionSemantic" />
         </GetSemanticVersion>
     </Target>

--- a/Build.Package.Verification.msbuild
+++ b/Build.Package.Verification.msbuild
@@ -46,14 +46,10 @@
     </Target>
     
     <PropertyGroup>
-        <FileGitVersionExe>GitHubFlowVersion.exe</FileGitVersionExe>
+        <FileSemanticVersion>$(DirBuildTemp)\semantic_version.json</FileSemanticVersion>
     </PropertyGroup>
     <Target Name="_GetSemanticVersion">
-        <FindToolFromPackages PackagesDir="$(DirPackages)" FileToLocate="$(FileGitVersionExe)">
-            <Output TaskParameter="Path" PropertyName="PathGitVersionExe" />
-        </FindToolFromPackages>
-        
-        <GetSemanticVersion ExePath="$(PathGitVersionExe)" TempDirectory="$(DirBuildTemp)">
+        <GetSemanticVersion VersionFile="$(FileSemanticVersion)">
             <Output TaskParameter="VersionMajor" PropertyName="VersionMajor" />
             <Output TaskParameter="VersionMinor" PropertyName="VersionMinor" />
             <Output TaskParameter="VersionSemanticFull" PropertyName="VersionSemanticFull" />

--- a/Build.PrepareWorkspace.msbuild
+++ b/Build.PrepareWorkspace.msbuild
@@ -20,10 +20,6 @@
        
         <!-- Tools -->
         <MsBuildExtensionsPath>$(DirTools)\msbuild.extensions</MsBuildExtensionsPath>
-        
-        <!-- Jenkins, the build system, adds the BZR_REVISION environment variable so we can get that here -->
-        <BZR_REVISION Condition="'$(BZR_REVISION)' == '' ">-1</BZR_REVISION>
-        <ScmRevision>$(BZR_REVISION)</ScmRevision>
     </PropertyGroup>
     
     <Import Project="$(MsBuildExtensionsPath)\NugetRestore.msbuild"

--- a/Deploy.GitTag.msbuild
+++ b/Deploy.GitTag.msbuild
@@ -29,14 +29,10 @@
     </Target>
     
     <PropertyGroup>
-        <FileGitVersionExe>GitHubFlowVersion.exe</FileGitVersionExe>
+        <FileSemanticVersion>$(DirBuildTemp)\semantic_version.json</FileSemanticVersion>
     </PropertyGroup>
     <Target Name="_GetSemanticVersion">
-        <FindToolFromPackages PackagesDir="$(DirPackages)" FileToLocate="$(FileGitVersionExe)">
-            <Output TaskParameter="Path" PropertyName="PathGitVersionExe" />
-        </FindToolFromPackages>
-        
-        <GetSemanticVersion ExePath="$(PathGitVersionExe)" TempDirectory="$(DirBuildTemp)">
+        <GetSemanticVersion VersionFile="$(FileSemanticVersion)">
             <Output TaskParameter="VersionSemantic" PropertyName="VersionSemantic" />
         </GetSemanticVersion>
     </Target>

--- a/src/solutionlevel/SolutionLevel.csproj
+++ b/src/solutionlevel/SolutionLevel.csproj
@@ -54,6 +54,7 @@
     <FileGeneratedWixVersion>$(DirBuildTemp)\VersionNumber.wxi</FileGeneratedWixVersion>
     <FileGeneratedWixDependencies>$(DirBuildTemp)\Dependencies.wxi</FileGeneratedWixDependencies>
     <FileGeneratedLicenses>$(DirBuildTemp)\licenses.xml</FileGeneratedLicenses>
+    <FileGeneratedSemanticVersion>$(DirBuildTemp)\semantic_version.json</FileGeneratedSemanticVersion>
     <!-- Version number -->
     <VersionMajor>0</VersionMajor>
     <VersionMinor>0</VersionMinor>
@@ -71,6 +72,7 @@
   </PropertyGroup>
   <Import Project="$(MsBuildExtensionsPath)\TemplateFile.msbuild" Condition="Exists('$(MsBuildExtensionsPath)\TemplateFile.msbuild')" />
   <Import Project="$(MsBuildExtensionsPath)\FindToolFromPackages.msbuild" Condition="Exists('$(MsBuildExtensionsPath)\FindToolFromPackages.msbuild')" />
+  <Import Project="$(MsBuildExtensionsPath)\CalculateSemanticVersion.msbuild" Condition="Exists('$(MsBuildExtensionsPath)\CalculateSemanticVersion.msbuild')" />
   <Import Project="$(MsBuildExtensionsPath)\GetSemanticVersion.msbuild" Condition="Exists('$(MsBuildExtensionsPath)\GetSemanticVersion.msbuild')" />
   <Import Project="$(MsBuildExtensionsPath)\GitCommitHash.msbuild" Condition="Exists('$(MsBuildExtensionsPath)\GitCommitHash.msbuild')" />
   <Import Project="$(MsBuildExtensionsPath)\PublicKeySignatureFromAssembly.msbuild" Condition="Exists('$(MsBuildExtensionsPath)\PublicKeySignatureFromAssembly.msbuild')" />
@@ -94,6 +96,7 @@
       <GeneratedFiles Include="$(FileGeneratedInternalsVisibleTo)" />
       <GeneratedFiles Include="$(FileGeneratedWixVersion)" />
       <GeneratedFiles Include="$(FileGeneratedWixDependencies)" />
+      <GeneratedFiles Include="$(FileGeneratedSemanticVersion)" />
     </ItemGroup>
     <Delete Files="@(GeneratedFiles)" />
   </Target>
@@ -117,7 +120,9 @@
       <Output TaskParameter="Path" PropertyName="PathGitVersionExe" />
     </FindToolFromPackages>
     
-    <GetSemanticVersion ExePath="$(PathGitVersionExe)" TempDirectory="$(DirBuildTemp)">
+    <CalculateSemanticVersion ExePath="$(PathGitVersionExe)" VersionFile="$(FileGeneratedSemanticVersion)" Condition="!Exists('$(FileGeneratedSemanticVersion)')" />
+    
+    <GetSemanticVersion VersionFile="$(FileGeneratedSemanticVersion)">
         <Output TaskParameter="VersionMajor" PropertyName="VersionMajor" />
         <Output TaskParameter="VersionMinor" PropertyName="VersionMinor" />
         <Output TaskParameter="VersionPatch" PropertyName="VersionPatch" />

--- a/tools/msbuild.extensions/CalculateSemanticVersion.msbuild
+++ b/tools/msbuild.extensions/CalculateSemanticVersion.msbuild
@@ -1,0 +1,70 @@
+<!-- 
+     Copyright 2013 nAnicitus. Licensed under the Apache License, Version 2.0.
+-->
+
+<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' 
+         ToolsVersion="4.0">
+    <UsingTask TaskName="CalculateSemanticVersion" 
+               TaskFactory="CodeTaskFactory" 
+               AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+        <ParameterGroup>
+            <ExePath ParameterType="System.String" Required="true" />
+            <VersionFile ParameterType="System.String" Required="true" />
+        </ParameterGroup>
+        <Task>
+            <Code Type="Method" Language="cs">
+                <![CDATA[
+                    public override bool Execute()
+                    {
+                        var info = new System.Diagnostics.ProcessStartInfo
+                        {
+                            FileName = ExePath,
+                            Arguments = string.Format("/ToFile \"{0}\"", VersionFile),
+                            UseShellExecute = false,
+                            RedirectStandardOutput = true,
+                            RedirectStandardError = true,
+                        };
+                        
+                        Log.LogMessage(MessageImportance.Normal, ExePath);
+                        Log.LogMessage(MessageImportance.Normal, info.Arguments);
+                        
+                        var process = new System.Diagnostics.Process();
+                        process.StartInfo = info;
+                        process.OutputDataReceived +=
+                            (s, e) =>
+                            {
+                                if (!string.IsNullOrWhiteSpace(e.Data))
+                                {
+                                    Log.LogMessage(MessageImportance.Normal, e.Data);
+                                }
+                            };
+                        process.ErrorDataReceived +=
+                            (s, e) =>
+                            {
+                                if (!string.IsNullOrWhiteSpace(e.Data))
+                                {
+                                    Log.LogError(e.Data);
+                                }
+                            };
+                        process.Start();
+
+                        process.BeginOutputReadLine();
+                        process.BeginErrorReadLine();
+                        process.WaitForExit();
+                        
+                        if (process.ExitCode != 0)
+                        {
+                            Log.LogError("Failed to get semantic version information");
+                            return false;
+                        }
+                        
+                        // Log.HasLoggedErrors is true if the task logged any errors -- even if they were logged 
+                        // from a task's constructor or property setter. As long as this task is written to always log an error
+                        // when it fails, we can reliably return HasLoggedErrors.
+                        return !Log.HasLoggedErrors;
+                    }
+                ]]>  
+            </Code>
+        </Task>
+    </UsingTask>
+</Project>

--- a/tools/msbuild.extensions/GetSemanticVersion.msbuild
+++ b/tools/msbuild.extensions/GetSemanticVersion.msbuild
@@ -1,5 +1,5 @@
 <!-- 
-     Copyright 2013 Sherlock. Licensed under the Apache License, Version 2.0.
+     Copyright 2013 nAnicitus. Licensed under the Apache License, Version 2.0.
 -->
 
 <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' 
@@ -8,8 +8,7 @@
                TaskFactory="CodeTaskFactory" 
                AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
         <ParameterGroup>
-            <ExePath ParameterType="System.String" Required="true" />
-            <TempDirectory ParameterType="System.String" Required="true" />
+            <VersionFile ParameterType="System.String" Required="true" />
             <VersionMajor ParameterType="System.String" Output="true" />
             <VersionMinor ParameterType="System.String" Output="true" />
             <VersionPatch ParameterType="System.String" Output="true" />
@@ -22,53 +21,10 @@
                 <![CDATA[
                     public override bool Execute()
                     {
-                        var outputPath = System.IO.Path.Combine(TempDirectory, "semantic_version.json");
-                        var info = new System.Diagnostics.ProcessStartInfo
-                        {
-                            FileName = ExePath,
-                            Arguments = string.Format("/ToFile \"{0}\"", outputPath),
-                            UseShellExecute = false,
-                            RedirectStandardOutput = true,
-                            RedirectStandardError = true,
-                        };
-                        
-                        Log.LogMessage(MessageImportance.Normal, ExePath);
-                        Log.LogMessage(MessageImportance.Normal, info.Arguments);
-                        
-                        var process = new System.Diagnostics.Process();
-                        process.StartInfo = info;
-                        process.OutputDataReceived +=
-                            (s, e) =>
-                            {
-                                if (!string.IsNullOrWhiteSpace(e.Data))
-                                {
-                                    Log.LogMessage(MessageImportance.Normal, e.Data);
-                                }
-                            };
-                        process.ErrorDataReceived +=
-                            (s, e) =>
-                            {
-                                if (!string.IsNullOrWhiteSpace(e.Data))
-                                {
-                                    Log.LogError(e.Data);
-                                }
-                            };
-                        process.Start();
-
-                        process.BeginOutputReadLine();
-                        process.BeginErrorReadLine();
-                        process.WaitForExit();
-                        
-                        if (process.ExitCode != 0)
-                        {
-                            Log.LogError("Failed to get semantic version information");
-                            return false;
-                        }
-                        
                         try
                         {
                             string text;
-                            using (var reader = new System.IO.StreamReader(outputPath))
+                            using (var reader = new System.IO.StreamReader(VersionFile))
                             {
                                 text = reader.ReadToEnd();
                             }


### PR DESCRIPTION
The Deploy.GitTag.msbuild script should use the same version file as the build process did.
